### PR TITLE
Feature/environment variables support

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/VSH-fbx-converter-unity.iml" filepath="$PROJECT_DIR$/.idea/VSH-fbx-converter-unity.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/Hub-Base-Asset-Pipeline.iml" filepath="$PROJECT_DIR$/.idea/Hub-Base-Asset-Pipeline.iml" />
     </modules>
   </component>
 </project>

--- a/asset_pipeline/arguments.py
+++ b/asset_pipeline/arguments.py
@@ -42,9 +42,9 @@ def parse():
     )
     # add optional argument to specify the hostname for a connection
     connection_group = parser.add_argument_group('Connection')
-    connection_group.add_argument('-H', '--host', '--hostname', help='hostname at which to connect to the holocloud®')
-    # add optional argument to specify the port for a connection to holocloud®
-    connection_group.add_argument('-P', '--port', type=int, help='port at which to connect to the holocloud®')
+    connection_group.add_argument('-H', '--host', '--hostname', help='hostname at which to connect to the Innoactive Hub®')
+    # add optional argument to specify the port for a connection to Innoactive Hub®
+    connection_group.add_argument('-P', '--port', type=int, help='port at which to connect to the Innoactive Hub®')
     # add optional argument to specify whether or not to use ssl
     parser.add_argument('-S', '--ssl', dest='ssl', action='store_true', help='whether or not to enforce ssl')
     connection_group.set_defaults(**connection_defaults)

--- a/asset_pipeline/client.py
+++ b/asset_pipeline/client.py
@@ -23,18 +23,18 @@ class ClientConfigParser():
     def __init__(self, config):
         self.config = config
         self.protocol = config.get('protocol', None) or 'http'
-        self.host = config.get('host')
-        self.port = config.get('port')
+        self.host = config.get('host', os.environ.get('ASSET_PIPELINE_HOST'))
+        self.port = config.get('port', os.environ.get('ASSET_PIPELINE_PORT'))
         self.ssl = config.get('ssl')
         # only if we didn't specify protocol explicitly
         if self.ssl and not config.get('protocpl'):
             self.protocol += 's'
         self.base_url = '{protocol}://{host}:{port}/'.format(protocol=self.protocol, host=self.host, port=self.port)
-        self.client_id = config.get('client_id')
-        self.client_secret = config.get('client_secret')
-        self.oauth_code = config.get('oauth_code')
-        self.username = config.get('username')
-        self.password = config.get('password')
+        self.client_id = config.get('client_id', os.environ.get('ASSET_PIPELINE_OAUTH_CLIENT_ID'))
+        self.client_secret = config.get('client_secret', os.environ.get('ASSET_PIPELINE_OAUTH_CLIENT_SECRET'))
+        self.oauth_code = config.get('oauth_code', os.environ.get('ASSET_PIPELINE_OAUTH_AUTH_CODE'))
+        self.username = config.get('username', os.environ.get('ASSET_PIPELINE_OAUTH_USERNAME'))
+        self.password = config.get('password', os.environ.get('ASSET_PIPELINE_OAUTH_PASSWORD'))
         if os.path.isfile(APPLICATION_STATE_FILE):
             with open(APPLICATION_STATE_FILE) as f:
                 self.state = pickle.load(f).get('state', None)

--- a/asset_pipeline/pipeline.py
+++ b/asset_pipeline/pipeline.py
@@ -106,7 +106,7 @@ class BaseRemoteAssetPipeline(AbstractAssetPipeline):
     """
     # default protocol for downloads is http
     protocol = 'http'
-    # the (web)socket over which we'll communicate with the holocloud®
+    # the (web)socket over which we'll communicate with the Innoactive Hub®
     socket = None
     # the host to connect to
     host = 'localhost'
@@ -162,7 +162,7 @@ class BaseRemoteAssetPipeline(AbstractAssetPipeline):
         :param socket: the newly opened websocket instance
         :return:
         """
-        logger.info('Successfully connected to holocloud®!')
+        logger.info('Successfully connected to Innoactive® Hub!')
 
     @staticmethod
     def on_socket_close(socket):
@@ -171,7 +171,7 @@ class BaseRemoteAssetPipeline(AbstractAssetPipeline):
         :param socket: the websocket instance which was closed
         :return:
         """
-        logger.info('Connection to holocloud® closed')
+        logger.info('Connection to Innoactive® Hub closed')
 
     @staticmethod
     def on_socket_error(socket, error):
@@ -270,7 +270,7 @@ class BaseRemoteAssetPipeline(AbstractAssetPipeline):
 
     def start(self):
         """
-        start this asset pipeline and connect it to the holocloud® to listen for updates / working instructions
+        start this asset pipeline and connect it to the Innoactive Hub® to listen for updates / working instructions
         :return:
         """
         logger.info('trying to connect to {}:{}'.format(self.host, self.port))
@@ -346,7 +346,7 @@ class PlatformSpecificAssetPipelineMixin(object):
 
     def start(self):
         """
-        start this asset pipeline and connect it to the holocloud® to listen for updates / working instructions
+        start this asset pipeline and connect it to the Innoactive Hub® to listen for updates / working instructions
         also, find out platform data before proceeding
         :return:
         """

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ pip install -U git+https://github.com/Innoactive/Hub-Base-Asset-Pipeline.git@0.1
 
 Afterwards, your pipeline implementation should be based on `BaseRemoteAssetPipeline`. 
 
-You can establish a connection between your newly created pipeline and the holocloud® by creating 
+You can establish a connection between your newly created pipeline and the Innoactive Hub® by creating 
 a command line script like the following: 
 
 ```python
@@ -70,9 +70,9 @@ foo=bar
 
 ## Existing Pipelines
 
-The following pipelines have already been successfully implemented and integrated with the holocloud®:
+The following pipelines have already been successfully implemented and integrated with the Innoactive Hub®:
 
-- [PDF Conversion Pipeline](https://github.com/Innoactive/HOLOCLOUD-pdf-pipeline)
+- [PDF Conversion Pipeline](https://github.com/Innoactive/Hub-PDF-Pipeline)
 
   Reads in a pdf file and outputs a set of high-resolution images that can be easily rendered
 

--- a/setup.py
+++ b/setup.py
@@ -21,15 +21,15 @@ def readme():
                 return f.read()
 
 
-setup(name='holocloud-asset-pipeline',
-      version='0.1',
-      description='Tools to connect a new asset pipeline to the holocloud®',
+setup(name='hub-asset-pipeline',
+      version='1.1.1',
+      description='Tools to connect a new asset pipeline to the Innoactive® Hub',
       long_description=readme(),
-      url='http://github.com/Innoactive/HOLOCLOUD-pipeline-connector',
+      url='https://github.com/Innoactive/Hub-Base-Asset-Pipeline',
       author='Benedikt Reiser',
       author_email='benedikt.reiser@gmail.com',
       license='MIT',
-      keywords=['holocloud', 'assets', 'pipeline', 'connector', 'websocket'],
+      keywords=['innoactive', 'hub', 'assets', 'pipeline', 'connector', 'websocket'],
       packages=find_packages(exclude=['docs', 'tests', 'tests.*']),
       install_requires=[
           'requests_oauthlib',


### PR DESCRIPTION
Allows specifying a bunch of settings via environment variables as a fallback if no `config.ini` file is provided: 

- `host`: `ASSET_PIPELINE_HOST`
- `port`: `ASSET_PIPELINE_PORT`
- `client_id `: `ASSET_PIPELINE_OAUTH_CLIENT_ID`
- `client_secret `: `ASSET_PIPELINE_OAUTH_CLIENT_SECRET`
- `auth_code`: `ASSET_PIPELINE_OAUTH_AUTH_CODE`
- `username`: `ASSET_PIPELINE_OAUTH_USERNAME`
- `password`: `ASSET_PIPELINE_OAUTH_PASSWORD`